### PR TITLE
Fix MetaLabel backgroundColor binding

### DIFF
--- a/android-ktx/src/main/java/com/mirego/trikot/metaviews/MetaLabelBinder.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/metaviews/MetaLabelBinder.kt
@@ -43,34 +43,6 @@ object MetaLabelBinder {
                 }
             }
 
-        label.backgroundColor.asLiveData()
-            .observe(lifecycleOwnerWrapper.lifecycleOwner) { selector ->
-                if (!selector.hasAnyValue) {
-                    return@observe
-                }
-
-                val defaultColor =
-                    Color.parseColor(selector.default?.hexARGB("#") ?: "#00000000")
-                val hoveredColor =
-                    selector.highlighted?.let { Color.parseColor(it.hexARGB("#")) }
-                        ?: defaultColor
-                val selectedColor =
-                    selector.selected?.let { Color.parseColor(it.hexARGB("#")) }
-                        ?: defaultColor
-                val disabledColor =
-                    selector.disabled?.let { Color.parseColor(it.hexARGB("#")) }
-                        ?: defaultColor
-                textView.backgroundTintList = ColorStateList(
-                    arrayOf(
-                        intArrayOf(R.attr.state_enabled),
-                        intArrayOf(R.attr.state_hovered),
-                        intArrayOf(R.attr.state_selected),
-                        intArrayOf(-R.attr.state_enabled)
-                    ),
-                    intArrayOf(defaultColor, hoveredColor, selectedColor, disabledColor)
-                )
-            }
-
         bindExtraViewProperties(textView, label, hiddenVisibility, lifecycleOwnerWrapper)
     }
 
@@ -110,14 +82,35 @@ object MetaLabelBinder {
             textView.alpha = alpha
         }
 
-        textView.bindOnTap(metaLabel, lifecycleOwnerWrapper)
-
         metaLabel.backgroundColor.asLiveData()
             .observe(lifecycleOwnerWrapper.lifecycleOwner) { selector ->
-                selector.default?.toIntColor()?.let {
-                    textView.setBackgroundColor(it)
+                if (!selector.hasAnyValue) {
+                    return@observe
                 }
+
+                val defaultColor =
+                    Color.parseColor(selector.default?.hexARGB("#") ?: "#00000000")
+                val hoveredColor =
+                    selector.highlighted?.let { Color.parseColor(it.hexARGB("#")) }
+                        ?: defaultColor
+                val selectedColor =
+                    selector.selected?.let { Color.parseColor(it.hexARGB("#")) }
+                        ?: defaultColor
+                val disabledColor =
+                    selector.disabled?.let { Color.parseColor(it.hexARGB("#")) }
+                        ?: defaultColor
+                textView.backgroundTintList = ColorStateList(
+                    arrayOf(
+                        intArrayOf(R.attr.state_enabled),
+                        intArrayOf(R.attr.state_hovered),
+                        intArrayOf(R.attr.state_selected),
+                        intArrayOf(-R.attr.state_enabled)
+                    ),
+                    intArrayOf(defaultColor, hoveredColor, selectedColor, disabledColor)
+                )
             }
+
+        textView.bindOnTap(metaLabel, lifecycleOwnerWrapper)
     }
 }
 

--- a/android-ktx/src/main/java/com/mirego/trikot/metaviews/MetaLabelBinder.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/metaviews/MetaLabelBinder.kt
@@ -88,26 +88,7 @@ object MetaLabelBinder {
                     return@observe
                 }
 
-                val defaultColor =
-                    Color.parseColor(selector.default?.hexARGB("#") ?: "#00000000")
-                val hoveredColor =
-                    selector.highlighted?.let { Color.parseColor(it.hexARGB("#")) }
-                        ?: defaultColor
-                val selectedColor =
-                    selector.selected?.let { Color.parseColor(it.hexARGB("#")) }
-                        ?: defaultColor
-                val disabledColor =
-                    selector.disabled?.let { Color.parseColor(it.hexARGB("#")) }
-                        ?: defaultColor
-                textView.backgroundTintList = ColorStateList(
-                    arrayOf(
-                        intArrayOf(R.attr.state_enabled),
-                        intArrayOf(R.attr.state_hovered),
-                        intArrayOf(R.attr.state_selected),
-                        intArrayOf(-R.attr.state_enabled)
-                    ),
-                    intArrayOf(defaultColor, hoveredColor, selectedColor, disabledColor)
-                )
+                textView.backgroundTintList = selector.toColorStateList()
             }
 
         textView.bindOnTap(metaLabel, lifecycleOwnerWrapper)


### PR DESCRIPTION
## Description

MataLabel's backgroundColor was binded twice + the background was override  instead of just changing the tintColor.

## How Has This Been Tested?
Google pixel 4

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
