### PR TITLE
Lower android SDK min version by using App compat library

### DIFF
--- a/android-ktx/build.gradle
+++ b/android-ktx/build.gradle
@@ -20,12 +20,12 @@ repositories {
 group 'com.mirego.trikot.metaviews'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "29.0.0"
+    compileSdkVersion 29
+    buildToolsVersion "29.0.3"
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 28
+        minSdkVersion 14
+        targetSdkVersion 29
     }
 
     dataBinding {
@@ -39,9 +39,10 @@ configurations.all {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    api 'com.mirego.trikot:metaviews:0.35.1'
+    api 'com.mirego.trikot:metaviews:0.41.1'
     implementation "com.mirego.trikot:android-ktx:$trikot_streams_android_ktx_version"
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.squareup.picasso:picasso:2.71828'
 }
 

--- a/android-ktx/src/main/java/com/mirego/trikot/metaviews/ColorExtentions.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/metaviews/ColorExtentions.kt
@@ -1,6 +1,5 @@
 package com.mirego.trikot.metaviews
 
-import android.R
 import android.content.res.ColorStateList
 import android.util.StateSet
 import com.mirego.trikot.metaviews.properties.Color
@@ -20,15 +19,15 @@ fun MetaSelector<Color>.toColorStateList(): ColorStateList {
 
     highlighted?.let {
         colors.add(it.toIntColor())
-        supportedMode.add(intArrayOf(R.attr.state_pressed))
+        supportedMode.add(intArrayOf(android.R.attr.state_pressed))
     }
     selected?.let {
         colors.add(it.toIntColor())
-        supportedMode.add(intArrayOf(R.attr.state_selected))
+        supportedMode.add(intArrayOf(android.R.attr.state_selected))
     }
     disabled?.let {
         colors.add(it.toIntColor())
-        supportedMode.add(intArrayOf(-R.attr.state_enabled))
+        supportedMode.add(intArrayOf(-android.R.attr.state_enabled))
     }
     default?.let {
         colors.add(it.toIntColor())

--- a/android-ktx/src/main/java/com/mirego/trikot/metaviews/ImageResourceExtensions.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/metaviews/ImageResourceExtensions.kt
@@ -1,10 +1,10 @@
 package com.mirego.trikot.metaviews
 
-import android.R
 import android.content.Context
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.StateListDrawable
 import android.util.StateSet
+import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
 import com.mirego.trikot.metaviews.properties.Color
 import com.mirego.trikot.metaviews.properties.MetaSelector
@@ -19,20 +19,20 @@ fun MetaSelector<ImageResource>.asDrawable(
 
     this.disabled?.let { imageResource ->
         imageResource.asDrawable(context, tintColor).let { drawable ->
-            stateListDrawable.addState(intArrayOf(-R.attr.state_enabled), drawable)
+            stateListDrawable.addState(intArrayOf(-android.R.attr.state_enabled), drawable)
         }
     }
 
     this.highlighted?.let { imageResource ->
         imageResource.asDrawable(context, tintColor).let { drawable ->
-            stateListDrawable.addState(intArrayOf(R.attr.state_pressed), drawable)
-            stateListDrawable.addState(intArrayOf(R.attr.state_focused), drawable)
+            stateListDrawable.addState(intArrayOf(android.R.attr.state_pressed), drawable)
+            stateListDrawable.addState(intArrayOf(android.R.attr.state_focused), drawable)
         }
     }
 
     this.selected?.let { imageResource ->
         imageResource.asDrawable(context, tintColor).let { drawable ->
-            stateListDrawable.addState(intArrayOf(R.attr.state_selected), drawable)
+            stateListDrawable.addState(intArrayOf(android.R.attr.state_selected), drawable)
         }
     }
 
@@ -53,9 +53,9 @@ fun ImageResource.asDrawable(
     context: Context,
     tintColors: MetaSelector<Color>? = null
 ): Drawable? {
-    return resourceId(context)?.let { resourceId -> context.getDrawable(resourceId) }?.also { drawable ->
+    return resourceId(context)?.let { resourceId -> ContextCompat.getDrawable(context, resourceId) }?.also { drawable ->
         if (tintColors?.hasAnyValue == true) {
-            drawable.mutate().setTintList(tintColors.toColorStateList())
+            DrawableCompat.setTintList(drawable.mutate(), tintColors.toColorStateList())
         }
     }
 }

--- a/android-ktx/src/main/java/com/mirego/trikot/metaviews/MetaButtonBinder.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/metaviews/MetaButtonBinder.kt
@@ -4,6 +4,7 @@ import android.view.View
 import android.widget.Button
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.core.view.ViewCompat
 import androidx.databinding.BindingAdapter
 import com.mirego.trikot.drawableBottom
 import com.mirego.trikot.drawableEnd
@@ -165,7 +166,7 @@ object MetaButtonBinder {
 
             it.backgroundColor.observe(lifecycleOwnerWrapper.lifecycleOwner) { selector ->
                 if (selector.hasAnyValue) {
-                    button.backgroundTintList = selector.toColorStateList()
+                    ViewCompat.setBackgroundTintList(button, selector.toColorStateList())
                 }
             }
 
@@ -177,7 +178,7 @@ object MetaButtonBinder {
 
             it.backgroundImageResource.observe(lifecycleOwnerWrapper.lifecycleOwner) { selector ->
                 if (selector.hasAnyValue) {
-                    button.background = selector.asDrawable(button.context, null)
+                    ViewCompat.setBackground(button, selector.asDrawable(button.context, null))
                 }
             }
         }

--- a/android-ktx/src/main/java/com/mirego/trikot/metaviews/MetaLabelBinder.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/metaviews/MetaLabelBinder.kt
@@ -1,13 +1,10 @@
 package com.mirego.trikot.metaviews
 
-import android.R
-import android.content.res.ColorStateList
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
-import android.text.SpannableString
-import android.text.Spanned
 import android.view.View
 import android.widget.TextView
+import androidx.core.view.ViewCompat
 import androidx.databinding.BindingAdapter
 import com.mirego.trikot.metaviews.mutable.MutableMetaLabel
 import com.mirego.trikot.streams.android.ktx.asLiveData
@@ -90,10 +87,10 @@ object MetaLabelBinder {
                 }
 
                 textView.background ?: run {
-                    textView.background = ColorDrawable(Color.WHITE)
+                    ViewCompat.setBackground(textView, ColorDrawable(Color.WHITE))
                 }
 
-                textView.backgroundTintList = selector.toColorStateList()
+                ViewCompat.setBackgroundTintList(textView, selector.toColorStateList())
             }
 
         textView.bindOnTap(metaLabel, lifecycleOwnerWrapper)

--- a/android-ktx/src/main/java/com/mirego/trikot/metaviews/MetaViewBinder.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/metaviews/MetaViewBinder.kt
@@ -1,10 +1,9 @@
 package com.mirego.trikot.metaviews
 
-import android.R
-import android.content.res.ColorStateList
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.view.View
+import androidx.core.view.ViewCompat
 import androidx.databinding.BindingAdapter
 import com.mirego.trikot.metaviews.mutable.MutableMetaView
 import com.mirego.trikot.metaviews.properties.MetaAction
@@ -38,10 +37,10 @@ fun View.bindMetaView(
                 }
 
                 background ?: run {
-                    background = ColorDrawable(Color.WHITE)
+                    ViewCompat.setBackground(this, ColorDrawable(Color.WHITE))
                 }
 
-                backgroundTintList = selector.toColorStateList()
+                ViewCompat.setBackgroundTintList(this, selector.toColorStateList())
             }
     }
 }


### PR DESCRIPTION
## Description
There was no really good reason to have this library to api level 21 only since all of the methods could be substituted by app compat calls (which also has workarounds around some specific API version bugs).

Also bumped some dependency versions.

## Motivation and Context
I needed to have API 19+ in my project. I lowered it even more since there was no reason not to.

## How Has This Been Tested?
Tested it in my project with min sdk api level 19

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
