### PR TITLE
Associated object need to be retained

### DIFF
--- a/swift-extensions/UIButtonExtensions.swift
+++ b/swift-extensions/UIButtonExtensions.swift
@@ -11,7 +11,7 @@ extension UIButton {
              return objc_getAssociatedObject(self, AssociatedKeys.onTapKey) as? MetaAction
         }
         set {
-            objc_setAssociatedObject(self, AssociatedKeys.onTapKey, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_ASSIGN)
+            objc_setAssociatedObject(self, AssociatedKeys.onTapKey, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN)
         }
     }
     


### PR DESCRIPTION
## Description
Fix a crash on iOS button binding. The tap action wasn't retained, so we could end up using a deallocated object.

## Motivation and Context
I prefer apps without crashes ;)

## How Has This Been Tested?
In my application

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
