### PR TITLE
Restore RichText color transform swift extension

### DIFF
--- a/swift-extensions/UIViewExtensions.swift
+++ b/swift-extensions/UIViewExtensions.swift
@@ -76,6 +76,10 @@ extension UIView {
                     fatalError("LabelViewModel RichText StyleTransform unsupported: \(transform.style)")
                 }
             }
+
+            if let transform = richTextRange.transform as? ColorTransform {
+                attributedString.addAttribute(.foregroundColor, value: transform.color.safeColor(), range: range)
+            }
         }
         return attributedString
     }


### PR DESCRIPTION
## Description

We restore the richText color transform that was mistakenly removed

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
